### PR TITLE
fix/make api key name optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ batchling create\
  --placeholders-path tests/test_data/placeholders_capitals.jsonl\
  --provider openai\
  --endpoint /v1/chat/completions\
- --api-key-name OPENAI_API_KEY\
  --input-file-path input_capitals_openai.jsonl\
  --output-file-path output/result_capitals.jsonl\
  --max-tokens-per-request 100
@@ -200,11 +199,14 @@ placeholders = [
 experiment = em.start_experiment(
     experiment_id="my-experiment-1",
     model="gpt-4o-mini",
+    provider="openai",
+    endpoint="/v1/chat/completions",
     name="My first experiment",
     description="Experimenting with gpt-4o-mini",
     template_messages=messages,
     placeholders=placeholders,
     input_file_path="path/to/write/input.jsonl",
+    output_file_path="path/to/write/output.jsonl",
 )
 
 # write a local input file with the right format

--- a/src/batchling/api_utils.py
+++ b/src/batchling/api_utils.py
@@ -1,0 +1,16 @@
+"""API utils"""
+
+
+def get_default_api_key_name_from_provider(provider: str | None = None) -> str:
+    if provider == "mistral":
+        return "MISTRAL_API_KEY"
+    elif provider == "groq":
+        return "GROQ_API_KEY"
+    elif provider == "together":
+        return "TOGETHER_API_KEY"
+    elif provider == "gemini":
+        return "GEMINI_API_KEY"
+    elif provider == "anthropic":
+        return "ANTHROPIC_API_KEY"
+    else:
+        return "OPENAI_API_KEY"

--- a/src/batchling/cli/main.py
+++ b/src/batchling/cli/main.py
@@ -122,7 +122,6 @@ def create_experiment(
     ],
     provider: Annotated[str, typer.Option(default=..., help="The provider to use")],
     endpoint: Annotated[str, typer.Option(default=..., help="The endpoint to use")],
-    api_key_name: Annotated[str, typer.Option(default=..., help="The name of the API key")],
     template_messages_path: Annotated[
         Path, typer.Option(default=..., help="The path to the template messages file")
     ],
@@ -133,6 +132,7 @@ def create_experiment(
     output_file_path: Annotated[
         Path, typer.Option(default=..., help="The path to the output file")
     ],
+    api_key_name: Annotated[str | None, typer.Option(help="The name of the API key")] = None,
     response_format_path: Annotated[
         Path | None, typer.Option(help="The path to the response format file")
     ] = None,

--- a/src/batchling/db/crud.py
+++ b/src/batchling/db/crud.py
@@ -10,11 +10,11 @@ def create_experiment(
     db: Session,
     id: str,
     model: str,
+    api_key_name: str = "OPENAI_API_KEY",
     name: str | None = None,
     description: str | None = None,
     provider: str = "openai",
     endpoint: str = "/v1/chat/completions",
-    api_key_name: str = "OPENAI_API_KEY",
     template_messages: list[dict] | None = None,
     placeholders: list[dict] | None = None,
     response_format: dict | None = None,
@@ -35,33 +35,33 @@ def create_experiment(
         The id of the experiment
     model : str
         The model to use for the experiment
-    name : str
+    api_key_name : str
+        The api key name of the experiment
+    name : str | None
         The name of the experiment
-    description : str
+    description : str | None
         The description of the experiment
     provider : str
         The provider of the experiment
     endpoint : str
         The endpoint of the experiment
-    api_key_name : str
-        The api key name of the experiment
-    template_messages : list[dict]
+    template_messages : list[dict] | None
         The template messages of the experiment
     placeholders : list[dict]
         The placeholders of the experiment
-    response_format : dict
+    response_format : dict | None
         The response format of the experiment
     max_tokens_per_request : int
         The max tokens per request of the experiment
-    input_file_path : str
+    input_file_path : str | None
         The path to the input file
     output_file_path : str
         The path to the output file
-    input_file_id : str
+    input_file_id : str | None
         The id of the input file
     is_setup : bool
         Whether the experiment is setup
-    batch_id : str
+    batch_id : str | None
         The id of the batch
     Returns
     -------

--- a/src/batchling/experiment_manager.py
+++ b/src/batchling/experiment_manager.py
@@ -1,6 +1,7 @@
 from dotenv import load_dotenv
 from pydantic import BaseModel, computed_field
 
+from batchling.api_utils import get_default_api_key_name_from_provider
 from batchling.cls_utils import get_experiment_cls_from_provider
 from batchling.db.crud import (
     create_experiment,
@@ -62,10 +63,10 @@ class ExperimentManager(BaseModel):
         experiment_id: str,
         model: str,
         name: str,
+        api_key_name: str | None = None,
         description: str | None = None,
         provider: str = "openai",
         endpoint: str = "/v1/chat/completions",
-        api_key_name: str = "OPENAI_API_KEY",
         template_messages: list[dict] | None = None,
         placeholders: list[dict] | None = None,
         response_format: BaseModel | dict | None = None,
@@ -86,7 +87,7 @@ class ExperimentManager(BaseModel):
                 description=description,
                 provider=provider,
                 endpoint=endpoint,
-                api_key_name=api_key_name,
+                api_key_name=api_key_name or get_default_api_key_name_from_provider(provider),
                 template_messages=template_messages,
                 placeholders=placeholders,
                 response_format=response_format,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,8 +28,6 @@ def test_create_experiment():
             "tests/test_data/placeholders_capitals.jsonl",
             "--input-file-path",
             "input_capitals.jsonl",
-            "--api-key-name",
-            "OPENAI_API_KEY",
             "--output-file-path",
             "output/result_capitals.jsonl",
         ],

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,6 @@
 import pytest
 
+from batchling.api_utils import get_default_api_key_name_from_provider
 from batchling.db.crud import (
     create_experiment,
     delete_experiment,
@@ -43,6 +44,7 @@ def test_get_experiment(db):
         model="gpt-4o-mini",
         name="test 2",
         description="test experiment number 2",
+        api_key_name=get_default_api_key_name_from_provider(provider="openai"),
     )
     experiment = get_experiment(db=db, id="experiment-test-2")
     assert experiment is not None
@@ -50,6 +52,7 @@ def test_get_experiment(db):
     assert experiment.id == "experiment-test-2"
     assert experiment.name == "test 2"
     assert experiment.description == "test experiment number 2"
+    assert experiment.api_key_name == "OPENAI_API_KEY"
 
 
 def test_update_experiment(db):


### PR DESCRIPTION
- **update python example and remove api_key_name**
- **make api_key_name optional and map with provider**
- **fix: make api_key_name optional in cli**
